### PR TITLE
Bug in sendkeys sleep intervals

### DIFF
--- a/src/smart/EventNazi.java
+++ b/src/smart/EventNazi.java
@@ -548,15 +548,15 @@ public class EventNazi {
                     long time = System.currentTimeMillis();
                     BlockingEventQueue.sendUnblocked(new KeyEvent(comp, KeyEvent.KEY_PRESSED, time, KeyEvent.SHIFT_MASK, code, c, keyLoc));
                     BlockingEventQueue.sendUnblocked(new KeyEvent(comp, KeyEvent.KEY_TYPED, time, KeyEvent.SHIFT_MASK, 0, c, KeyEvent.KEY_LOCATION_UNKNOWN));
-                    try { Thread.sleep((int)((Math.random() * 0.1 + 1) + keywait)); } catch (Exception e) { e.printStackTrace(); }
+                    try { Thread.sleep((int)((Math.random() * 0.1 + 1) * keywait)); } catch (Exception e) { e.printStackTrace(); }
                     BlockingEventQueue.sendUnblocked(new KeyEvent(comp, KeyEvent.KEY_RELEASED, System.currentTimeMillis(), KeyEvent.SHIFT_MASK, code, c, keyLoc));
-                    try { Thread.sleep((int)((Math.random() * 0.1 + 1) + keymodwait)); } catch (Exception e) { e.printStackTrace(); }
+                    try { Thread.sleep((int)((Math.random() * 0.1 + 1) * keymodwait)); } catch (Exception e) { e.printStackTrace(); }
                     BlockingEventQueue.sendUnblocked(new KeyEvent(comp, KeyEvent.KEY_RELEASED, System.currentTimeMillis(), 0, KeyEvent.VK_SHIFT, KeyEvent.CHAR_UNDEFINED, shiftLoc));
                 } else {
                     long time = System.currentTimeMillis();
                     BlockingEventQueue.sendUnblocked(new KeyEvent(comp, KeyEvent.KEY_PRESSED, time, 0, code, c, keyLoc));
                     BlockingEventQueue.sendUnblocked(new KeyEvent(comp, KeyEvent.KEY_TYPED, time, 0, 0, c, KeyEvent.KEY_LOCATION_UNKNOWN));
-                    try { Thread.sleep((int)((Math.random() * 0.1 + 1) + keywait)); } catch (Exception e) { e.printStackTrace(); }
+                    try { Thread.sleep((int)((Math.random() * 0.1 + 1) * keywait)); } catch (Exception e) { e.printStackTrace(); }
                     BlockingEventQueue.sendUnblocked(new KeyEvent(comp, KeyEvent.KEY_RELEASED, System.currentTimeMillis(), 0, code, c, keyLoc));
                 }
             }


### PR DESCRIPTION
Hey, I came across this bug in sendkeys, I'm assuming the first interval was correct as multiplying seems like the logical thing to do in calculating the intervals.
