### PR TITLE
option to specify filepath for SMART.* files

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -882,8 +882,6 @@ public class Main {
      * launch a SMART client and setup the shared memory / socket communication.
      */
     public static void main(String[] exec_args) {
-        if (exec_args.length != 9) System.exit(1);
-         
         String path = new File(exec_args[0]).getAbsolutePath();
         System.load(path);
         String root = exec_args[1];
@@ -893,8 +891,10 @@ public class Main {
         String initseq = exec_args[5];
         String useragent = exec_args[6];
 		
-		String pluginspath = exec_args[7];
-		String pluginsinfo = exec_args[8];
+	String pluginspath = exec_args[7];
+	String pluginsinfo = exec_args[8];
+	
+	String filepath = exec_args[9];
         
         int nVars = 7;
         int argsSpace = 4096;
@@ -907,7 +907,7 @@ public class Main {
         try {
             id = getPID();
             debug("Starting remote " + id);
-            File f = new File("SMART."+id);
+            File f = new File(filepath+"SMART."+id);
             if (f.exists()) f.delete();
             f.createNewFile();
             f.deleteOnExit();

--- a/src/SmartRemote.cpp
+++ b/src/SmartRemote.cpp
@@ -295,7 +295,7 @@ SMARTClient* pairClient(int id) {
  * Creates a remote SMART client and pairs to it
  * FIXME javaargs not handled for linux
  */
-SMARTClient* spawnClient(char *java_exec, char* remote_path, char *root, char *params, int width, int height, char *initseq, char *useragent, char* javaargs, char* plugins) {
+SMARTClient* spawnClient(char *java_exec, char* remote_path, char *root, char *params, int width, int height, char *initseq, char *useragent, char* javaargs, char* plugins, char* filepath) {
     cleanupSHM();
     SMARTClient *client;
     if (!remote_path || !root || !params) return 0;
@@ -312,9 +312,9 @@ SMARTClient* spawnClient(char *java_exec, char* remote_path, char *root, char *p
     sprintf(bootclasspath,"-Xbootclasspath/p:\"%s/%s\"",remote_path,"smart.jar");
     char library[512];
     sprintf(library,"%s/libsmartjni%s.dll",remote_path,bits);
-    int len = strlen(javaargs)+strlen(bootclasspath)+strlen(library)+strlen(root)+strlen(params)+strlen(_width)+strlen(_height)+strlen(initseq)+strlen(useragent)+strlen(remote_path)+strlen(plugins)+7*3+50; //A little extra
+    int len = strlen(javaargs)+strlen(bootclasspath)+strlen(library)+strlen(root)+strlen(params)+strlen(_width)+strlen(_height)+strlen(initseq)+strlen(useragent)+strlen(remote_path)+strlen(plugins)+strlen(filepath)+7*3+50; //A little extra
     char *args = new char[len];
-    sprintf(args,"%s %s smart.Main \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\"",javaargs,bootclasspath,library,root,params,_width,_height,initseq,useragent, remote_path, plugins);
+    sprintf(args,"%s %s smart.Main \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\"",javaargs,bootclasspath,library,root,params,_width,_height,initseq,useragent, remote_path, plugins, filepath);
 	SHELLEXECUTEINFO info;
     memset(&info, 0, sizeof(SHELLEXECUTEINFO));
     info.cbSize = sizeof(SHELLEXECUTEINFO); 
@@ -358,7 +358,7 @@ SMARTClient* spawnClient(char *java_exec, char* remote_path, char *root, char *p
         callClient(client,Ping);
         return client;
     } else {
-        execlp(java_exec,java_exec,bootclasspath,"smart.Main",library,root,params,_width,_height,initseq,useragent, remote_path, plugins, NULL);
+        execlp(java_exec,java_exec,bootclasspath,"smart.Main",library,root,params,_width,_height,initseq,useragent, remote_path, plugins, filepath, NULL);
         debug << "Process terminating. If nothing happened, make sure java is on your path and that SMART is installed correctly.\n";
         exit(1);
     }
@@ -480,8 +480,8 @@ bool exp_killClient(int pid) {
  * Creates a remote SMART client and pairs to it. Returns the target to be used
  * in target-specific methods, or NULL on failure.
  */
-Target exp_spawnClient(char* java_exec, char* remote_path, char *root, char *params, int width, int height, char *initseq, char *useragent, char* javaargs, char* plugins) {
-    return spawnClient(java_exec, remote_path,root,params,width,height,initseq,useragent,javaargs,plugins);
+Target exp_spawnClient(char* java_exec, char* remote_path, char *root, char *params, int width, int height, char *initseq, char *useragent, char* javaargs, char* plugins, char* filepath) {
+    return spawnClient(java_exec, remote_path,root,params,width,height,initseq,useragent,javaargs,plugins,filepath);
 }
 
 /**

--- a/src/SmartRemote.h
+++ b/src/SmartRemote.h
@@ -208,7 +208,7 @@ extern "C" bool EIOS_IsKeyHeld(Target t, int key) __attribute__((stdcall));
 extern "C" int exp_getClients(bool only_unpaired);
 extern "C" int exp_getAvailablePID(int idx);
 extern "C" bool exp_killClient(int pid);
-extern "C" Target exp_spawnClient(char* java_exec, char* remote_path, char *root, char *params, int width, int height, char *initseq, char *useragent, char* javaargs, char* plugins);
+extern "C" Target exp_spawnClient(char* java_exec, char* remote_path, char *root, char *params, int width, int height, char *initseq, char *useragent, char* javaargs, char* plugins, char* filepath);
 extern "C" Target exp_pairClient(int pid);
 extern "C" int exp_getClientPID(Target t);
 extern "C" void exp_freeClient(Target t);
@@ -301,7 +301,7 @@ static char* exports[] = {
     (char*)"exp_getAvailablePID", (char*)"function SmartGetAvailablePID(idx: integer): integer;",
     (char*)"exp_killClient", (char*)"function SmartKillClient(pid: integer): boolean;",
     (char*)"exp_pairClient", (char*)"function SmartPairClient(pid: integer): PtrUInt;",
-    (char*)"exp_spawnClient",(char*)"function SmartSpawnClient(java_exec, remote_path, root, params: string; width, height: integer; initseq, useragent, javaargs, Plugins: string): PtrUInt;",
+    (char*)"exp_spawnClient",(char*)"function SmartSpawnClient(java_exec, remote_path, root, params: string; width, height: integer; initseq, useragent, javaargs, Plugins: string; filepath: string): PtrUInt;",
     (char*)"exp_freeClient", (char*)"procedure SmartFreeClient(target: PtrUInt);",
     (char*)"exp_getClientPID", (char*)"function SmartGetClientPID(target: PtrUInt): integer;",
     (char*)"exp_getImageArray", (char*)"function SmartImageArray(target: PtrUInt): PtrUInt;",


### PR DESCRIPTION
This will keep the directory of the scripts clean, and allows scripts started from a different directory to reuse the SMART.

I'm having trouble getting it to work though, the optional param isn't working (access violation if i leave out 1 argument). Any idea what i'm doing wrongly?

EDIT: removed the default arg, gave this error when the script is executed from a different directory than filepath:

```
Error: client.init:1103 sun.reflect.NativeMethodAccessorImpl.invoke0 sun.reflect
.NativeMethodAccessorImpl.invoke sun.reflect.DelegatingMethodAccessorImpl.invoke
 java.lang.reflect.Method.invoke Rs2Applet.a:116 Rs2Applet.init:509 smart.Client
.initFrame:618 smart.Client.<init>:141 smart.Main.main:954 | java.lang.RuntimeEx
ception |
```

looks like there's something else that relies on the SMART.\* files? 
